### PR TITLE
react-i18next v8.0.0 incompatibility fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18next-scanner",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Scan your code, extract translation keys/values, and merge them into i18n resource files.",
   "homepage": "https://github.com/i18next/i18next-scanner",
   "author": "Cheton Wu <cheton@gmail.com>",
@@ -9,6 +9,11 @@
       "name": "Cheton Wu",
       "email": "cheton@gmail.com",
       "url": "https://github.com/cheton"
+    },
+    {
+      "name": "Gabriel Haruki",
+      "email": "gabrielharukisatoh@gmail.com",
+      "url": "https://github.com/Harukisatoh"
     }
   ],
   "bin": {

--- a/src/nodes-to-string.js
+++ b/src/nodes-to-string.js
@@ -55,7 +55,7 @@ const nodesToString = (nodes, code) => {
             } if (isStringLiteral(expression)) {
                 memo += expression.value;
             } else if (isObjectExpression(expression) && (_get(expression, 'properties[0].type') === 'Property')) {
-                memo += `<${nodeIndex}>{{${expression.properties[0].key.name}}}</${nodeIndex}>`;
+                memo += `{{${expression.properties[0].key.name}}}`;
             } else {
                 console.error(`Unsupported JSX expression. Only static values or {{interpolation}} blocks are supported. Got ${expression.type}:`);
                 console.error(code.slice(node.start, node.end));

--- a/test/jsx-parser.js
+++ b/test/jsx-parser.js
@@ -23,7 +23,7 @@ const jsxToString = (code) => {
 
 test('JSX to i18next', (t) => {
     t.same(jsxToString('Basic text'), 'Basic text');
-    t.same(jsxToString('Hello, {{name}}'), 'Hello, <1>{{name}}</1>');
+    t.same(jsxToString('Hello, {{name}}'), 'Hello, {{name}}');
     t.same(jsxToString('I agree to the <Link>terms</Link>.'), 'I agree to the <1>terms</1>.');
     t.same(jsxToString('One &amp; two'), 'One & two');
     t.end();

--- a/test/parser.js
+++ b/test/parser.js
@@ -163,8 +163,8 @@ test('Parse Trans components', (t) => {
     t.same(parser.get(), {
         en: {
             dev: {
-                'Hello <1>World</1>, you have <3>{{count}}</3> unread message.': 'Hello <1>World</1>, you have <3>{{count}}</3> unread message.',
-                'Hello <1>World</1>, you have <3>{{count}}</3> unread message._plural': 'Hello <1>World</1>, you have <3>{{count}}</3> unread message.'
+                'Hello <1>World</1>, you have {{count}} unread message.': 'Hello <1>World</1>, you have {{count}} unread message.',
+                'Hello <1>World</1>, you have {{count}} unread message._plural': 'Hello <1>World</1>, you have {{count}} unread message.'
             },
             translation: {
                 // quote style
@@ -172,8 +172,8 @@ test('Parse Trans components', (t) => {
                 'jsx-quotes-single': 'Use single quote for the i18nKey attribute',
 
                 // plural
-                'plural': 'You have <1>{{count}}</1> apples',
-                'plural_plural': 'You have <1>{{count}}</1> apples',
+                'plural': 'You have {{count}} apples',
+                'plural_plural': 'You have {{count}} apples',
 
                 // context
                 'context': 'A boyfriend',
@@ -182,8 +182,8 @@ test('Parse Trans components', (t) => {
                 // i18nKey
                 'multiline-text-string': 'multiline text string',
                 'string-literal': 'This is a <1>test</1>',
-                'object-expression': 'This is a <1><0>{{test}}</0></1>',
-                'arithmetic-expression': '2 + 2 = <1>{{result}}</1>',
+                'object-expression': 'This is a <1>{{test}}</1>',
+                'arithmetic-expression': '2 + 2 = {{result}}',
                 'components': 'Go to <1>Administration > Tools</1> to download administrative tools.',
                 'lorem-ipsum': '<0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<2>Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s</2>',
                 'lorem-ipsum-nested': 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</1></1><2>Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s</2>',
@@ -192,8 +192,8 @@ test('Parse Trans components', (t) => {
                 'Hello, World!': 'Hello, World!',
                 'multiline text string': 'multiline text string',
                 'This is a <1>test</1>': 'This is a <1>test</1>',
-                'This is a <1><0>{{test}}</0></1>': 'This is a <1><0>{{test}}</0></1>',
-                '2 + 2 = <1>{{result}}</1>': '2 + 2 = <1>{{result}}</1>',
+                'This is a <1>{{test}}</1>': 'This is a <1>{{test}}</1>',
+                '2 + 2 = {{result}}': '2 + 2 = {{result}}',
                 'Go to <1>Administration > Tools</1> to download administrative tools.': 'Go to <1>Administration > Tools</1> to download administrative tools.',
                 '<0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<2>Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s</2>': '<0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<2>Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s</2>',
                 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</1></1><2>Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s</2>': 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</1></1><2>Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s</2>',
@@ -237,8 +237,8 @@ test('Parse Trans components with fallback key', (t) => {
     t.same(parser.get(), {
         en: {
             dev: {
-                '2290678f8f33c49494499fe5e32b4ebd124d9292': 'Hello <1>World</1>, you have <3>{{count}}</3> unread message.',
-                '2290678f8f33c49494499fe5e32b4ebd124d9292_plural': 'Hello <1>World</1>, you have <3>{{count}}</3> unread message.'
+                'bcaa73c8812acd93f897f113a1f6166189596fc5': 'Hello <1>World</1>, you have {{count}} unread message.',
+                'bcaa73c8812acd93f897f113a1f6166189596fc5_plural': 'Hello <1>World</1>, you have {{count}} unread message.'
             },
             translation: {
                 // quote style
@@ -246,8 +246,8 @@ test('Parse Trans components with fallback key', (t) => {
                 'jsx-quotes-single': 'Use single quote for the i18nKey attribute',
 
                 // plural
-                'plural': 'You have <1>{{count}}</1> apples',
-                'plural_plural': 'You have <1>{{count}}</1> apples',
+                'plural': 'You have {{count}} apples',
+                'plural_plural': 'You have {{count}} apples',
 
                 // context
                 'context': 'A boyfriend',
@@ -256,8 +256,8 @@ test('Parse Trans components with fallback key', (t) => {
                 // i18nKey
                 'multiline-text-string': 'multiline text string',
                 'string-literal': 'This is a <1>test</1>',
-                'object-expression': 'This is a <1><0>{{test}}</0></1>',
-                'arithmetic-expression': '2 + 2 = <1>{{result}}</1>',
+                'object-expression': 'This is a <1>{{test}}</1>',
+                'arithmetic-expression': '2 + 2 = {{result}}',
                 'components': 'Go to <1>Administration > Tools</1> to download administrative tools.',
                 'lorem-ipsum': '<0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<2>Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s</2>',
                 'lorem-ipsum-nested': 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</1></1><2>Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s</2>',
@@ -266,8 +266,8 @@ test('Parse Trans components with fallback key', (t) => {
                 '0a0a9f2a6772942557ab5355d76af442f8f65e01': 'Hello, World!',
                 '32876cbad378f3153c900c297ed2efa06243e0e2': 'multiline text string',
                 'e4ca61dff6bc759d214e32c4e37c8ae594ca163d': 'This is a <1>test</1>',
-                '0ce90193dd25c93cdc12f25a36d31004a74c63de': 'This is a <1><0>{{test}}</0></1>',
-                '493781e20cd3cfd5b3137963519571c3d97ab383': '2 + 2 = <1>{{result}}</1>',
+                '49794e6e13cb1be2987c790d7e6d21f724cc3d5b': 'This is a <1>{{test}}</1>',
+                'd9ad3431d982619e3b7bd34ed248205312e95bff': '2 + 2 = {{result}}',
                 '083eac6b4f73ec317824caaaeea57fba3b83c1d9': 'Go to <1>Administration > Tools</1> to download administrative tools.',
                 '938c04be9e14562b7532a19458fe92b65c6ef941': '<0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<2>Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s</2>',
                 '9c3ca5d5d8089e96135c8c7c9f42ba34a635fb47': 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</1></1><2>Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s</2>',

--- a/test/transform-stream.js
+++ b/test/transform-stream.js
@@ -188,8 +188,8 @@ test('[Trans Component] fallbackKey', function(t) {
                     "jsx-quotes-single": "Use single quote for the i18nKey attribute",
 
                     // plural
-                    "plural": "You have <1>{{count}}</1> apples",
-                    "plural_plural": "You have <1>{{count}}</1> apples",
+                    "plural": "You have {{count}} apples",
+                    "plural_plural": "You have {{count}} apples",
 
                     // context
                     "context": "A boyfriend",
@@ -198,8 +198,8 @@ test('[Trans Component] fallbackKey', function(t) {
                     // i18nKey
                     "multiline-text-string": "multiline text string",
                     "string-literal": "This is a <1>test</1>",
-                    "object-expression": "This is a <1><0>{{test}}</0></1>",
-                    "arithmetic-expression": "2 + 2 = <1>{{result}}</1>",
+                    "object-expression": "This is a <1>{{test}}</1>",
+                    "arithmetic-expression": "2 + 2 = {{result}}",
                     "components": "Go to <1>Administration > Tools</1> to download administrative tools.",
                     "lorem-ipsum": "<0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<2>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s</2>",
                     "lorem-ipsum-nested": "Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</1></1><2>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s</2>",
@@ -208,8 +208,8 @@ test('[Trans Component] fallbackKey', function(t) {
                     "Hello, World!": "Hello, World!",
                     "multiline text string": "multiline text string",
                     "This is a <1>test</1>": "This is a <1>test</1>",
-                    "This is a <1><0>{{test}}</0></1>": "This is a <1><0>{{test}}</0></1>",
-                    "2 + 2 = <1>{{result}}</1>": "2 + 2 = <1>{{result}}</1>",
+                    "This is a <1>{{test}}</1>": "This is a <1>{{test}}</1>",
+                    "2 + 2 = {{result}}": "2 + 2 = {{result}}",
                     "Go to <1>Administration > Tools</1> to download administrative tools.": "Go to <1>Administration > Tools</1> to download administrative tools.",
                     "<0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<2>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s</2>": "<0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</0>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<2>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s</2>",
                     "Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</1></1><2>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s</2>": "Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.<1>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</1></1><2>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s</2>",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
Makes i18next-scanner-fix compatible to react-i18next v8.0.0 by removing variables node indexes tags from translations. For more info check: https://github.com/i18next/i18next-scanner/issues/125

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided